### PR TITLE
Support customisation in congrats bot and add README 

### DIFF
--- a/.github/congratsbot.mjs
+++ b/.github/congratsbot.mjs
@@ -37,7 +37,7 @@ function setDiscordMessage(author, id, commitMsg, repo) {
     coAuthorThanks = '\n' + getCoAuthorsMessage(names);
   }
 
-  const defaultEmoji = ['🎉', '🎊', '🧑‍🚀', '🥳', '🙌', '🚀', '🤩', '☄️', '💫'];
+  const defaultEmoji = ['🎉', '🎊', '🧑‍🚀', '🥳', '🙌', '🚀'];
   const userEmoji = process.env.EMOJIS?.split(',');
   const emoji = pick(
     userEmoji && userEmoji.length > 0 ? userEmoji : defaultEmoji
@@ -107,7 +107,7 @@ function getCoAuthorsMessage(names) {
       'Thanks <names> for helping! ✨',
       '<names> stepped up to lend a hand — thank you! 🙌',
       '<names> with the assist! 💪',
-      'Couldn’t have done this without <names>! 💖',
+      'Couldn’t have done this without <names>! 💜',
       'Made even better by <names>! 🚀',
       'And the team effort award goes to… <names>! 🏆',
       'Featuring contributions by <names>! 🌟',

--- a/.github/congratsbot.mjs
+++ b/.github/congratsbot.mjs
@@ -37,7 +37,11 @@ function setDiscordMessage(author, id, commitMsg, repo) {
     coAuthorThanks = '\n' + getCoAuthorsMessage(names);
   }
 
-  const emoji = pick(['🎉', '🎊', '🧑‍🚀', '🥳', '🙌', '🚀', '🤩', '☄️', '💫']);
+  const defaultEmoji = ['🎉', '🎊', '🧑‍🚀', '🥳', '🙌', '🚀', '🤩', '☄️', '💫'];
+  const userEmoji = process.env.EMOJIS?.split(',');
+  const emoji = pick(
+    userEmoji && userEmoji.length > 0 ? userEmoji : defaultEmoji
+  );
 
   setGitHubActionOutput(
     'DISCORD_MESSAGE',
@@ -88,15 +92,27 @@ function pick(items) {
  * @param {string} names Names of co-authors to be thanked
  */
 function getCoAuthorsMessage(names) {
-  const messages = [
-    '_Thanks <names> for helping!_ ✨',
-    '_<names> stepped up to lend a hand — thank you!_ 🙌',
-    '_<names> with the assist!_ 💪',
-    '_Couldn’t have done this without <names>!_ 💖',
-    '_Made even better by <names>!_ 🚀',
-    '_And the team effort award goes to… <names>!_ 🏆',
-    '_Featuring contributions by <names>!_ 🌟',
-  ];
+  /** @type {string[]} */
+  let messages = [];
+  try {
+    messages = JSON.parse(process.env.COAUTHOR_TEMPLATES || '[]');
+  } catch (err) {
+    console.error(
+      'Failed to parse `COAUTHOR_TEMPLATES` as JSON. Falling back to default templates.\n ',
+      err
+    );
+  }
+  if (!messages || messages.length === 0) {
+    messages = [
+      'Thanks <names> for helping! ✨',
+      '<names> stepped up to lend a hand — thank you! 🙌',
+      '<names> with the assist! 💪',
+      'Couldn’t have done this without <names>! 💖',
+      'Made even better by <names>! 🚀',
+      'And the team effort award goes to… <names>! 🏆',
+      'Featuring contributions by <names>! 🌟',
+    ];
+  }
   const chosenMessage = pick(messages);
-  return chosenMessage.replace('<names>', names);
+  return '_' + chosenMessage.replace('<names>', names).trim() + '_';
 }

--- a/.github/congratsbot.mjs
+++ b/.github/congratsbot.mjs
@@ -27,8 +27,8 @@ function setDiscordMessage(author, id, commitMsg, repo) {
   const coAuthors = commitMsg
     .split('\n')
     .slice(2)
-    .filter((line) => line.match(/Co-authored-by: (.+) <.+>/))
-    .map((line) => line.match(/Co-authored-by: (.+) <.+>/)[1]);
+    .filter((line) => line.match(/Co-authored-by: (.+) <.+>/i))
+    .map((line) => line.match(/Co-authored-by: (.+) <.+>/i)[1]);
 
   let coAuthorThanks = '';
   if (coAuthors.length) {

--- a/.github/congratsbot.mjs
+++ b/.github/congratsbot.mjs
@@ -37,6 +37,8 @@ function setDiscordMessage(author, id, commitMsg, repo) {
     coAuthorThanks = '\n' + getCoAuthorsMessage(names);
   }
 
+  console.log({ commitMsg, coAuthors, coAuthorThanks });
+
   const defaultEmoji = ['🎉', '🎊', '🧑‍🚀', '🥳', '🙌', '🚀', '🤩', '☄️', '💫'];
   const userEmoji = process.env.EMOJIS?.split(',');
   const emoji = pick(
@@ -113,6 +115,7 @@ function getCoAuthorsMessage(names) {
       'Featuring contributions by <names>! 🌟',
     ];
   }
+  console.log({ messages });
   const chosenMessage = pick(messages);
   return '_' + chosenMessage.replace('<names>', names).trim() + '_';
 }

--- a/.github/congratsbot.mjs
+++ b/.github/congratsbot.mjs
@@ -37,8 +37,6 @@ function setDiscordMessage(author, id, commitMsg, repo) {
     coAuthorThanks = '\n' + getCoAuthorsMessage(names);
   }
 
-  console.log({ commitMsg, coAuthors, coAuthorThanks });
-
   const defaultEmoji = ['🎉', '🎊', '🧑‍🚀', '🥳', '🙌', '🚀', '🤩', '☄️', '💫'];
   const userEmoji = process.env.EMOJIS?.split(',');
   const emoji = pick(
@@ -115,7 +113,6 @@ function getCoAuthorsMessage(names) {
       'Featuring contributions by <names>! 🌟',
     ];
   }
-  console.log({ messages });
   const chosenMessage = pick(messages);
   return '_' + chosenMessage.replace('<names>', names).trim() + '_';
 }

--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -16,7 +16,7 @@ on:
         description: >
           Comma-delimited set of emojis.
           Each congrats bot message will pick one at random for the start of the message.
-        default: 🎉,🎊,🧑‍🚀,🥳,🙌,🚀,🤩,☄️,💫
+        default: 🎉,🎊,🧑‍🚀,🥳,🙌,🚀
         type: string
         required: false
       COAUTHOR_TEMPLATES:
@@ -32,7 +32,7 @@ on:
             "Thanks <names> for helping! ✨",
             "<names> stepped up to lend a hand — thank you! 🙌",
             "<names> with the assist! 💪",
-            "Couldn’t have done this without <names>! 💖",
+            "Couldn’t have done this without <names>! 💜",
             "Made even better by <names>! 🚀",
             "And the team effort award goes to… <names>! 🏆",
             "Featuring contributions by <names>! 🌟"

--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -6,18 +6,33 @@ on:
       DISCORD_WEBHOOK:
         required: true
     inputs:
-      GITHUB_REPO:
-        required: true
+      EMOJIS:
+        description: >
+          Comma-delimited set of emojis.
+          Each congrats bot message will pick one at random for the start of the message.
+        default: 🎉,🎊,🧑‍🚀,🥳,🙌,🚀,🤩,☄️,💫
         type: string
-      COMMIT_AUTHOR:
-        required: true
+        required: false
+      COAUTHOR_TEMPLATES:
+        description: >
+          A JSON array of co-author recognition templates.
+          Each template should contain the `<names>` placeholder.
+          This will be replaced by the names of one or more co-authors for this commit.
+          (Ignored for commits without any co-authors.)
+
+          When designing templates, bear in mind that `<names>` could be one, two, or more names.
+        default: >
+          [
+            "Thanks <names> for helping! ✨",
+            "<names> stepped up to lend a hand — thank you! 🙌",
+            "<names> with the assist! 💪",
+            "Couldn’t have done this without <names>! 💖",
+            "Made even better by <names>! 🚀",
+            "And the team effort award goes to… <names>! 🏆",
+            "Featuring contributions by <names>! 🌟"
+          ]
         type: string
-      COMMIT_MESSAGE:
-        required: true
-        type: string
-      COMMIT_ID:
-        required: true
-        type: string
+        required: false
 
 jobs:
   post-message:
@@ -38,10 +53,12 @@ jobs:
       - id: message
         name: Format Discord message
         env:
-          GITHUB_REPO: ${{ inputs.GITHUB_REPO }}
-          COMMIT_AUTHOR: ${{ inputs.COMMIT_AUTHOR }}
-          COMMIT_MESSAGE: ${{ inputs.COMMIT_MESSAGE }}
-          COMMIT_ID: ${{ inputs.COMMIT_ID }}
+          GITHUB_REPO: ${{ github.event.repository.full_name }}
+          COMMIT_AUTHOR: ${{ github.event.commits[0].author.name }}
+          COMMIT_MESSAGE: ${{ github.event.commits[0].message }}
+          COMMIT_ID: ${{ github.event.commits[0].id }}
+          EMOJIS: ${{ inputs.EMOJIS }}
+          COAUTHOR_TEMPLATES: ${{ inputs.COAUTHOR_TEMPLATES }}
         run: node automation/.github/congratsbot.mjs
 
       - name: Send message on Discord

--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'withastro/automation'
-          ref: 'chris/congrats'
+          ref: 'main'
           path: 'automation'
 
       - name: Setup Node

--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -4,6 +4,12 @@ on:
   workflow_call:
     secrets:
       DISCORD_WEBHOOK:
+        description: >
+          URL of a Discord webhook. To create one:
+            1. Find the channel you want to post congrats in.
+            2. Right-click and select “Edit Channel”.
+            3. Navigate to “Integrations” > “View Webhooks”.
+            4. Click “New Webhook” and copy the URL for your newly created webhook.
         required: true
     inputs:
       EMOJIS:

--- a/.github/workflows/congratsbot.yml
+++ b/.github/workflows/congratsbot.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'withastro/automation'
-          ref: 'main'
+          ref: 'chris/congrats'
           path: 'automation'
 
       - name: Setup Node

--- a/README.md
+++ b/README.md
@@ -1,0 +1,118 @@
+# Astro Automation Tools
+
+This repository contains GitHub Action workflows that are shared across repos in the `withastro` GitHub org.
+
+> **Warning**  
+> These workflows are not designed for use _outside_ of the `withastro` GitHub org.
+
+## [`congratsbot.yml`](./.github/workflows/congratsbot.yml)
+
+This workflow posts a celebratory message in a Discord channel of your choice for each commit. For example:
+
+> 🎊 **Merged!** Houston (Bot): [`[ci] release (#232)`](#)  
+> _Featuring contributions by github-actions[bot]! 🌟_
+
+### Prerequisites
+
+[Create a new Discord webhook](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) and add the URL to your repository secrets as `DISCORD_WEBHOOK_CONGRATS`.
+
+### Usage
+
+```yml
+name: Congratsbot
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  congrats:
+    if: ${{ github.repository_owner == 'withastro' }}
+    uses: withastro/automation/.github/workflows/congratsbot.yml@main
+    secrets:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}
+```
+
+### Optional inputs
+
+You can customize the emojis and co-author message templates to give your repository its own personality. You can set these under `with` in your job:
+
+```yml
+jobs:
+  congrats:
+    if: ${{ github.repository_owner == 'withastro' }}
+    uses: withastro/automation/.github/workflows/congratsbot.yml@main
+    with:
+      EMOJIS: 🤖,👻,😱
+      COAUTHOR_TEMPLATES: >
+        [
+          "Woahhh, <names> really gave us a fright! 🎃",
+          "We weren’t sure what we were doing until <names> showed up. 🤝"
+        ]
+    secrets:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}
+```
+
+#### `EMOJIS`
+
+**default:** `🎉,🎊,🧑‍🚀,🥳,🙌,🚀,🤩,☄️,💫`
+
+A comma-delimited set of emojis.
+Each congrats bot message will pick one at random for the start of the message.
+
+#### `COAUTHOR_TEMPLATES`
+
+**default:** see [`congratsbot.yml`](./.github/workflows/congratsbot.yml#L31)
+
+A JSON array of co-author recognition templates.
+Each template should contain the `<names>` placeholder to be replaced by the names of one or more co-authors for this commit.
+(Ignored for commits without any co-authors.)
+
+When designing templates, bear in mind that `<names>` could be one, two, or more names.
+
+## [`format.yml`](./.github/workflows/format.yml)
+
+This workflow runs a repository’s code formatting tooling (e.g. Prettier) and commits any resulting changes directly.
+
+### Usage
+
+```yml
+name: Format
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  prettier:
+    if: github.repository_owner == 'withastro'
+    uses: withastro/automation/.github/workflows/format.yml@main
+    with:
+      # Set command to this repository’s package script that runs Prettier
+      command: 'format:ci'
+    secrets: inherit
+```
+
+## [`lockfile.yml`](./.github/workflows/lockfile.yml)
+
+This workflow updates a repository’s `pnpm-lock.yaml` and opens a PR with the changes if there are any.
+
+### Usage
+
+```yml
+name: Nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every Monday at 12:00 UTC
+    - cron: '0 12 * * 1'
+
+jobs:
+  lockfile:
+    if: github.repository_owner == 'withastro'
+    uses: withastro/automation/.github/workflows/lockfile.yml@main
+    secrets: inherit
+```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ jobs:
 
 #### `EMOJIS`
 
-**default:** `🎉,🎊,🧑‍🚀,🥳,🙌,🚀,🤩,☄️,💫`
+**default:** `🎉,🎊,🧑‍🚀,🥳,🙌,🚀`
 
 A comma-delimited set of emojis.
 Each congrats bot message will pick one at random for the start of the message.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A JSON array of co-author recognition templates.
 Each template should contain the `<names>` placeholder to be replaced by the names of one or more co-authors for this commit.
 (Ignored for commits without any co-authors.)
 
-When designing templates, bear in mind that `<names>` could be one, two, or more names.
+When writing congrats messages, remember that `<names>` could be one, two, or more names. So, create messages that can work for both a single co-author and for several people, for example, "This PR was made even better by `<names>`!"
 
 ## [`format.yml`](./.github/workflows/format.yml)
 


### PR DESCRIPTION
- Simplify basic usage of the CongratsBot workflow by removing the need for any inputs by default
- Add optional `EMOJIS` and `COAUTHOR_TEMPLATES` inputs to CongratsBot to support adding a bit of personality to each instance
- Uses the “docs” variants as the defaults for `EMOJIS` and `COAUTHOR_TEMPLATES` (slightly less sparkly/starry)
- Adds a README to the repo with docs for the different workflows. Skipped documenting `pnpm.yaml` as it doesn’t seem to be used anywhere?

Tested by running Starlight’s congrats bot against this branch to confirm it’s working.