### PR TITLE
Ignore github-actions[bot]

### DIFF
--- a/.github/congratsbot.mjs
+++ b/.github/congratsbot.mjs
@@ -34,11 +34,11 @@ function setDiscordMessage(author, id, commitMsg, repo) {
   if (coAuthors.length) {
     const uniqueCoAuthors = [...new Set(coAuthors)];
     const names = makeList(uniqueCoAuthors).filter(name => 
-		{
-			if(name == "github-actions[bot]")
-				return false;
-			return true;
-		});
+    {
+        if(name == "github-actions[bot]")
+            return false;
+        return true;
+    });
     coAuthorThanks = '\n' + getCoAuthorsMessage(names);
   }
 

--- a/.github/congratsbot.mjs
+++ b/.github/congratsbot.mjs
@@ -33,7 +33,12 @@ function setDiscordMessage(author, id, commitMsg, repo) {
   let coAuthorThanks = '';
   if (coAuthors.length) {
     const uniqueCoAuthors = [...new Set(coAuthors)];
-    const names = makeList(uniqueCoAuthors);
+    const names = makeList(uniqueCoAuthors).filter(name => 
+		{
+			if(name == "github-actions[bot]")
+				return false;
+			return true;
+		});
     coAuthorThanks = '\n' + getCoAuthorsMessage(names);
   }
 


### PR DESCRIPTION
I noticed that occasionally, the congrats webhook would thank "github-actions[bot]". Given the fact that this is meant to highlight the contributions of other people who worked on something, I felt like it should ignore the bot. If anyone feels otherwise, feel free to close.

An example of it happening:
![image](https://github.com/withastro/automation/assets/49076509/6c73decf-1267-4f49-8024-1f15dc96924e)
