### PR TITLE
Use same username for congrats and format

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -44,3 +44,4 @@ jobs:
           branch: ${{ github.head_ref }}
           commit_user_name: astrobot-houston
           commit_user_email: fred+astrobot@astro.build
+          commit_author: ${{ github.event.commits[0].author.name }} <${{ github.actor }}@users.noreply.github.com>


### PR DESCRIPTION
I noticed that when the format workflow ran, it would use the Github username instead of the display name. This should fix that.
This is adapted from the [congrats workflow](https://github.com/withastro/automation/blob/main/.github/workflows/congratsbot.yml#L63C1-L63C24) and the [default author used withing the action we use](https://github.com/stefanzweifel/git-auto-commit-action/blob/master/action.yml#L43-L46).

Examples of the issue occuring:
![image](https://github.com/withastro/automation/assets/49076509/d4287e68-14ca-4a5b-8c5b-def2022b41c1)
![image](https://github.com/withastro/automation/assets/49076509/7cd5ad66-7601-4938-bb60-dd38be30de0b)
