### PR TITLE
Update CongratsBot

### DIFF
--- a/.github/congratsbot.mjs
+++ b/.github/congratsbot.mjs
@@ -1,4 +1,4 @@
-import { EOL } from 'node:os';
+import { setOutput } from './utils.mjs'
 
 const { COMMIT_AUTHOR, COMMIT_ID, COMMIT_MESSAGE, GITHUB_REPO } = process.env;
 if (!COMMIT_AUTHOR || !COMMIT_ID || !COMMIT_MESSAGE || !GITHUB_REPO) {
@@ -44,30 +44,10 @@ function setDiscordMessage(author, id, commitMsg, repo) {
     userEmoji && userEmoji.length > 0 ? userEmoji : defaultEmoji
   );
 
-  setGitHubActionOutput(
+  setOutput(
     'DISCORD_MESSAGE',
     `${emoji} **Merged!** ${author}: [\`${commitMessage}\`](<https://github.com/${repo}/commit/${id}>)${coAuthorThanks}`
   );
-}
-
-/**
- * Based on `setOutput` and `issueCommand` in `@actions/core` to avoid the additional dependency.
- * @see https://github.com/actions/toolkit/blob/a6bf8726aa7b78d4fc8111359cca5d538527b239/packages/core/src/core.ts#L192
- * @see https://github.com/actions/toolkit/blob/a6bf8726aa7b78d4fc8111359cca5d538527b239/packages/core/src/command.ts#L23
- * @param {string} name Name of the output value to set
- * @param {string} value Value to set
- */
-function setGitHubActionOutput(name, value) {
-  process.stdout.write(EOL);
-  process.stdout.write(`::set-output name=${name}::` + escapeData(value) + EOL);
-}
-
-/**
- * Based on https://github.com/actions/toolkit/blob/a6bf8726aa7b78d4fc8111359cca5d538527b239/packages/core/src/command.ts#LL80C1-L85C2
- * @param {string} str
- */
-function escapeData(str) {
-  return str.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
 }
 
 /**

--- a/.github/utils.mjs
+++ b/.github/utils.mjs
@@ -1,6 +1,6 @@
-import * as fs from 'fs'
-import * as os from 'os'
-import {v4 as uuidv4} from 'uuid'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as crypto from 'node:crypto'
 
 /** Based on https://github.com/actions/toolkit/blob/4e3b068ce116d28cb840033c02f912100b4592b0/packages/core/src/file-command.ts */
 export function setOutput(key, value) {
@@ -28,7 +28,7 @@ function issueFileCommand(command, message) {
 }
 
 function prepareKeyValueMessage(key, value) {
-  const delimiter = `ghadelimiter_${uuidv4()}`
+  const delimiter = `gh-delimiter-${crypto.randomUUID()}`
   const convertedValue = toCommandValue(value)
 
   // These should realistically never happen, but just in case someone finds a

--- a/.github/utils.mjs
+++ b/.github/utils.mjs
@@ -1,0 +1,59 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import {v4 as uuidv4} from 'uuid'
+
+/** Based on https://github.com/actions/toolkit/blob/4e3b068ce116d28cb840033c02f912100b4592b0/packages/core/src/file-command.ts */
+export function setOutput(key, value) {
+  const filePath = process.env['GITHUB_OUTPUT'] || ''
+  if (filePath) {
+    return issueFileCommand('OUTPUT', prepareKeyValueMessage(key, value))
+  }
+  process.stdout.write(os.EOL)
+}
+
+function issueFileCommand(command, message) {
+  const filePath = process.env[`GITHUB_${command}`]
+  if (!filePath) {
+    throw new Error(
+      `Unable to find environment variable for file command ${command}`
+    )
+  }
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Missing file at path: ${filePath}`)
+  }
+
+  fs.appendFileSync(filePath, `${toCommandValue(message)}${os.EOL}`, {
+    encoding: 'utf8'
+  })
+}
+
+function prepareKeyValueMessage(key, value) {
+  const delimiter = `ghadelimiter_${uuidv4()}`
+  const convertedValue = toCommandValue(value)
+
+  // These should realistically never happen, but just in case someone finds a
+  // way to exploit uuid generation let's not allow keys or values that contain
+  // the delimiter.
+  if (key.includes(delimiter)) {
+    throw new Error(
+      `Unexpected input: name should not contain the delimiter "${delimiter}"`
+    )
+  }
+
+  if (convertedValue.includes(delimiter)) {
+    throw new Error(
+      `Unexpected input: value should not contain the delimiter "${delimiter}"`
+    )
+  }
+
+  return `${key}<<${delimiter}${os.EOL}${convertedValue}${os.EOL}${delimiter}`
+}
+
+function toCommandValue(input) {
+  if (input === null || input === undefined) {
+    return ''
+  } else if (typeof input === 'string' || input instanceof String) {
+    return input
+  }
+  return JSON.stringify(input)
+}


### PR DESCRIPTION
Updates `congratsbot` to use the currently supported `GITHUB_OUTPUT` format rather than the deprecated `::set-output`