### PR TITLE
Wait 3 days before updating workflow dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,7 @@
   ],
   rangeStrategy: 'bump',
   ignorePaths: ['**/node_modules/**'],
+  minimumReleaseAge: '3 days',
   packageRules: [
     {
       groupName: 'github-actions',


### PR DESCRIPTION
Updates our Renovate config to wait 3 days after publication before updating workflow deps