### PR TITLE
Add draft release workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,9 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+template: |
+  # Changelog
+
+  $CHANGES
+
+  See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release.
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,20 @@
+name: Draft release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  draft-release:
+    if: github.repository == 'withastro/automation'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -94,3 +94,12 @@ jobs:
       command: 'format:ci'
     secrets: inherit
 ```
+
+## Releases
+
+To publish a new release of the reusable workflows:
+
+1. Merge the desired changes to main.
+1. Review the automatically generated draft release.
+1. Update the release tag and title if needed.
+1. Publish the release.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ on:
 jobs:
   congrats:
     if: ${{ github.repository_owner == 'withastro' }}
-    uses: withastro/automation/.github/workflows/congratsbot.yml@main
+    uses: withastro/automation/.github/workflows/congratsbot.yml@<commit-sha> # vX.Y.Z
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}
 ```
@@ -41,7 +41,7 @@ You can customize the emojis and co-author message templates to give your reposi
 jobs:
   congrats:
     if: ${{ github.repository_owner == 'withastro' }}
-    uses: withastro/automation/.github/workflows/congratsbot.yml@main
+    uses: withastro/automation/.github/workflows/congratsbot.yml@<commit-sha> # vX.Y.Z
     with:
       EMOJIS: 🤖,👻,😱
       COAUTHOR_TEMPLATES: >
@@ -88,7 +88,7 @@ on:
 jobs:
   prettier:
     if: github.repository_owner == 'withastro'
-    uses: withastro/automation/.github/workflows/format.yml@main
+    uses: withastro/automation/.github/workflows/format.yml@<commit-sha> # vX.Y.Z
     with:
       # Set command to this repository’s package script that runs Prettier
       command: 'format:ci'


### PR DESCRIPTION
#### Description

As a follow-up to this [Discord discussion](https://discord.com/channels/830184174198718474/1507425718374633544) and to avoid workaround like [this one](https://github.com/withastro/starlight/pull/3914), this PR adds a workflow to automatically generate a draft release when changes are merged to `main`, similar to part of the process used in the [`withastro/action` repo](https://github.com/withastro/action/tree/main/.github).

- I did not add the [workflow](https://github.com/withastro/action/blob/main/.github/workflows/release.yml) that creates or updates a major version tag, such as `v1`, to point at the latest release, as we want to encourage usage using a commit SHA with the corresponding version tag (e.g. `uses: withastro/automation/.github/workflows/format.yml@<commit-sha> # vX.Y.Z`) inside the organization.
- I did not add any configuration regarding labels for `release-drafter/release-drafter` as I don't think we would end up using them. The default version resolver strategy is `patch` and we can always update the release tag and title if needed before publishing the release.
- For the first release, we should manually remove the `all code changes` link as there is no previous tag to compare against.

I guess the only remaining question would be what should be the first version number?