### PR TITLE
Fix `release-drafter` excludes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,11 +7,6 @@ template: |
 
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release.
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
-categories:
-  - type: "pre-exclude"
-    title: "Internal dependencies to ignore"
-    when:
-      paths-mode: only
-      paths:
-        - ".github/workflows/draft-release.yml"
-        - ".github/release-drafter.yml"
+exclude-paths:
+  - ".github/workflows/draft-release.yml"
+  - ".github/release-drafter.yml"


### PR DESCRIPTION
#### Description

This PR fixes the `release-drafter/release-drafter` excludes made in https://github.com/withastro/automation/pull/65 and https://github.com/withastro/automation/commit/3e735d87bb9d4139dd14e88247c1d90d404f2d85.

Turns out this was [recently entirely refactored](https://github.com/release-drafter/release-drafter/compare/v7.3.1...refs/heads/master) in the `release-drafter/release-drafter` action but not yet released, so by checking the documentation on the default branch we were using invalid configuration options.

This PR uses the `exclude-paths` option documented from the `7.3.1` documentation: https://github.com/release-drafter/release-drafter/tree/v7.3.1