### PR TITLE
Fix release drafter config for v7.4.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,6 +7,11 @@ template: |
 
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release.
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
-exclude-paths:
-  - ".github/workflows/draft-release.yml"
-  - ".github/release-drafter.yml"
+categories:
+  - type: "pre-exclude"
+    title: "Internal dependencies to ignore"
+    when:
+      paths-mode: only
+      paths:
+        - ".github/workflows/draft-release.yml"
+        - ".github/release-drafter.yml"


### PR DESCRIPTION
This PR reverts #66 to use the new `categories` config approach instead of the deprecated `exclude-paths` config.

I noticed in a recent run that there is now a deprecation warning logged due to our use of `exclude-paths` because we updated the release drafter action to 7.4.0. This version released the new config approach that was not available last time we were configuring this.

If I understand the docs correctly, this change is also an improvement: currently, if a PR touches any of our `exclude-paths` it is not included in the relase notes, even if it touched a relevant file. The new config style should fix that.