### PR TITLE
Cloudflare deploy workflows

### DIFF
--- a/.github/workflows/cloudflare-deploy-preview.yml
+++ b/.github/workflows/cloudflare-deploy-preview.yml
@@ -1,0 +1,173 @@
+name: Cloudflare Deploy Preview
+
+# Reusable workflow that publishes a Cloudflare Worker preview for a pull request
+# and comments the preview URL on the PR.
+#
+# This is the second half of a two-workflow split (see `cloudflare-deploy.yml`).
+# The caller must trigger this via `workflow_run` on completion of the workflow
+# that uses `cloudflare-deploy.yml`. Running on `workflow_run` means this executes
+# in the trusted base-repo context (with the Cloudflare token and PR-write access)
+# while only ever consuming artifacts produced by the untrusted PR build — it
+# never checks out or executes PR code.
+#
+# Only sanitized, constrained values from the artifacts (a numeric PR number and
+# an [a-z0-9-] alias) are interpolated into scripts, so untrusted branch content
+# cannot be injected.
+
+on:
+  workflow_call:
+    inputs:
+      worker-name:
+        description: >
+          Name of the Worker to publish the preview against. Previews are always
+          created on this Worker so they resolve on its preview domain.
+        required: true
+        type: string
+      wrangler-version:
+        description: 'Pin the wrangler version used by wrangler-action. Uses the action default when empty.'
+        required: false
+        type: string
+        default: ""
+    secrets:
+      CLOUDFLARE_API_TOKEN:
+        description: 'Cloudflare API token with permission to publish preview versions of the Worker.'
+        required: true
+
+# Cancel older preview runs for the same branch so a stale deploy doesn't
+# overwrite the comment from a newer one.
+concurrency:
+  group: preview-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: >-
+      github.repository_owner == 'withastro' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download PR metadata
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pr-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: pr-metadata
+
+      - name: Read PR metadata
+        id: metadata
+        run: |
+          echo "pr_number=$(cat pr-metadata/pr_number)" >> "$GITHUB_OUTPUT"
+          echo "preview_alias=$(cat pr-metadata/preview_alias)" >> "$GITHUB_OUTPUT"
+          echo "preview_url=$(cat pr-metadata/preview_url)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment deployment in progress
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.metadata.outputs.pr_number }}', 10);
+            const previewUrl = '${{ steps.metadata.outputs.preview_url }}';
+            const commitSHA = '${{ github.event.workflow_run.head_sha }}';
+            const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const body = `**Preview deployment**\n\n`
+              + `🔄 Deployment in progress...\n\n`
+              + `- **Latest commit:** ${commitSHA}\n`
+              + `- **Preview:** ${previewUrl}\n`
+              + `- **Workflow run:** [View logs](${runUrl})`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.user.login === 'github-actions[bot]' && c.body.includes('**Preview deployment**'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+      - name: Download build output
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-output
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Deploy preview
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          wranglerVersion: ${{ inputs.wrangler-version }}
+          # Always create the preview on the named Worker so previews use its
+          # preview domain, even for PRs targeting version branches.
+          command: preview --worker-name ${{ inputs.worker-name }} --name "${{ steps.metadata.outputs.preview_alias }}"
+
+      - name: Comment deployment complete
+        if: success()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.metadata.outputs.pr_number }}', 10);
+            const previewUrl = '${{ steps.metadata.outputs.preview_url }}';
+            const commitSHA = '${{ github.event.workflow_run.head_sha }}';
+            const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const body = `**Preview deployment**\n\n`
+              + `✅ Deployment complete!\n\n`
+              + `- **Latest commit:** ${commitSHA}\n`
+              + `- **Preview:** ${previewUrl}\n`
+              + `- **Workflow run:** [View logs](${runUrl})`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.user.login === 'github-actions[bot]' && c.body.includes('**Preview deployment**'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            }
+
+      - name: Comment deployment failed
+        if: failure()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.metadata.outputs.pr_number }}', 10);
+            const commitSHA = '${{ github.event.workflow_run.head_sha }}';
+            const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const body = `**Preview deployment**\n\n`
+              + `❌ Deployment failed!\n\n`
+              + `- **Latest commit:** ${commitSHA}\n`
+              + `- **Workflow run:** [View logs](${runUrl})`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.user.login === 'github-actions[bot]' && c.body.includes('**Preview deployment**'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            }

--- a/.github/workflows/cloudflare-deploy-preview.yml
+++ b/.github/workflows/cloudflare-deploy-preview.yml
@@ -74,10 +74,12 @@ jobs:
             const commitSHA = '${{ github.event.workflow_run.head_sha }}';
             const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
             const body = `**Preview deployment**\n\n`
-              + `🔄 Deployment in progress...\n\n`
-              + `- **Latest commit:** ${commitSHA}\n`
-              + `- **Preview:** ${previewUrl}\n`
-              + `- **Workflow run:** [View logs](${runUrl})`;
+              + `| | |\n`
+              + `| :-- | :-- |\n`
+              + `| **Status** | 🔄 In progress… |\n`
+              + `| **Preview** | ${previewUrl} |\n`
+              + `| **Commit** | \`${commitSHA}\` |\n`
+              + `| **Logs** | [View logs](${runUrl}) |`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -126,10 +128,12 @@ jobs:
             const commitSHA = '${{ github.event.workflow_run.head_sha }}';
             const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
             const body = `**Preview deployment**\n\n`
-              + `✅ Deployment complete!\n\n`
-              + `- **Latest commit:** ${commitSHA}\n`
-              + `- **Preview:** ${previewUrl}\n`
-              + `- **Workflow run:** [View logs](${runUrl})`;
+              + `| | |\n`
+              + `| :-- | :-- |\n`
+              + `| **Status** | ✅ Complete! |\n`
+              + `| **Preview** | ${previewUrl} |\n`
+              + `| **Commit** | \`${commitSHA}\` |\n`
+              + `| **Logs** | [View logs](${runUrl}) |`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -154,9 +158,11 @@ jobs:
             const commitSHA = '${{ github.event.workflow_run.head_sha }}';
             const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
             const body = `**Preview deployment**\n\n`
-              + `❌ Deployment failed!\n\n`
-              + `- **Latest commit:** ${commitSHA}\n`
-              + `- **Workflow run:** [View logs](${runUrl})`;
+              + `| | |\n`
+              + `| :-- | :-- |\n`
+              + `| **Status** | ❌ Failed! |\n`
+              + `| **Commit** | \`${commitSHA}\` |\n`
+              + `| **Logs** | [View logs](${runUrl}) |`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -109,6 +109,9 @@ jobs:
         run: ${{ inputs.build-command }}
 
       - name: Deploy
+        # Production deploy only. This runs on `push` (e.g. merges to a
+        # production branch), never on `pull_request`, so it is skipped for
+        # PRs — including fork PRs, which don't have access to the token.
         if: ${{ github.event_name == 'push' }}
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:

--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -1,0 +1,153 @@
+name: Cloudflare Deploy
+
+# Reusable workflow that deploys a Cloudflare Worker on pushes to a production
+# branch, and on pull requests uploads the build output + PR metadata so that
+# the companion `cloudflare-deploy-preview.yml` workflow can publish a preview
+# from the trusted base-repo context.
+#
+# This is one half of a two-workflow split. The split is required for security:
+# this workflow runs on the `pull_request` event (untrusted fork code, no access
+# to the Cloudflare token on forks), so it never deploys PR code directly. It
+# only deploys to production on `push`, and hands PRs off via artifacts.
+#
+# See `cloudflare-deploy-preview.yml` for the second half.
+
+on:
+  workflow_call:
+    inputs:
+      preview-domain:
+        description: >
+          Base domain used to build preview URLs, e.g. "previews.docs.astro.build".
+          The branch alias is prepended, producing "<alias>.previews.docs.astro.build".
+        required: true
+        type: string
+      artifact-paths:
+        description: >
+          Newline-delimited list of files/directories to upload as the preview
+          build output (consumed by cloudflare-deploy-preview.yml). Must include
+          your wrangler config and everything `wrangler deploy` needs, e.g.:
+            dist/
+            worker.js
+            wrangler.jsonc
+        required: true
+        type: string
+      deploy-command:
+        description: 'The wrangler-action command used for the production deploy.'
+        required: false
+        type: string
+        default: "deploy"
+      build-command:
+        description: 'Optional shell command that produces the build output. Skipped when empty.'
+        required: false
+        type: string
+        default: ""
+      install-command:
+        description: 'Optional shell command to install dependencies (e.g. "pnpm install"). Skipped when empty.'
+        required: false
+        type: string
+        default: ""
+      node-version:
+        description: 'If set, Node.js (and pnpm when package-manager is "pnpm") is installed with this version.'
+        required: false
+        type: string
+        default: ""
+      package-manager:
+        description: 'Package manager used for dependency caching: "pnpm" or "npm".'
+        required: false
+        type: string
+        default: "pnpm"
+      node-options:
+        description: 'Optional value for the NODE_OPTIONS env var during the build (e.g. "--max_old_space_size=8192").'
+        required: false
+        type: string
+        default: ""
+      wrangler-version:
+        description: 'Pin the wrangler version used by wrangler-action. Uses the action default when empty.'
+        required: false
+        type: string
+        default: ""
+    secrets:
+      CLOUDFLARE_API_TOKEN:
+        description: 'Cloudflare API token with permission to deploy the Worker.'
+        required: true
+
+# Automatically cancel in-progress runs on the same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: ${{ github.repository_owner == 'withastro' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      NODE_OPTIONS: ${{ inputs.node-options }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup PNPM
+        if: ${{ inputs.node-version != '' && inputs.package-manager == 'pnpm' }}
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node
+        if: ${{ inputs.node-version != '' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: ${{ inputs.install-command != '' }}
+        run: ${{ inputs.install-command }}
+
+      - name: Build
+        if: ${{ inputs.build-command != '' }}
+        run: ${{ inputs.build-command }}
+
+      - name: Deploy
+        if: ${{ github.event_name == 'push' }}
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          wranglerVersion: ${{ inputs.wrangler-version }}
+          command: ${{ inputs.deploy-command }}
+
+      - name: Upload build output
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: build-output
+          path: ${{ inputs.artifact-paths }}
+
+      - name: Save PR metadata
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.head_ref }}
+          PREVIEW_DOMAIN: ${{ inputs.preview-domain }}
+        run: |
+          mkdir -p pr-metadata
+          echo "$PR_NUMBER" > pr-metadata/pr_number
+          BRANCH="$HEAD_REF"
+          # Sanitize branch name into a valid Wrangler preview alias.
+          # Wrangler validates aliases against /^[a-z](?:[a-z0-9-]*[a-z0-9])?$/i so the
+          # alias must start with a letter, contain only [a-z0-9-], and end with a letter
+          # or digit. It is also used as the subdomain for the preview URL, e.g.
+          # "my-branch.previews.docs.astro.build".
+          ALIAS=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/^-//' | sed 's/-$//')
+          # Prefix "pr-" if the alias starts with a digit (e.g. branch "260616") so it
+          # satisfies the "must start with a letter" rule.
+          [[ "$ALIAS" =~ ^[0-9] ]] && ALIAS="pr-$ALIAS"
+          echo "$ALIAS" > pr-metadata/preview_alias
+          echo "https://${ALIAS}.${PREVIEW_DOMAIN}" > pr-metadata/preview_url
+
+      - name: Upload PR metadata
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-metadata
+          path: pr-metadata/

--- a/README.md
+++ b/README.md
@@ -95,6 +95,96 @@ jobs:
     secrets: inherit
 ```
 
+## Cloudflare Worker deploys
+
+Two reusable workflows deploy a Cloudflare Worker to production on pushes and publish per-PR previews. They are split into two files on purpose, for security: the deploy workflow runs on the `pull_request` event (untrusted fork code, no token on forks) and never deploys PR code — it only deploys to production on `push` and hands PRs off as artifacts. The preview workflow runs on `workflow_run` in the trusted base-repo context, consuming only those artifacts (it never checks out or runs PR code) and interpolating only sanitized values (a numeric PR number and an `[a-z0-9-]` alias).
+
+Using both gives you production deploys on your default branch plus a `https://<branch-alias>.<preview-domain>` preview commented on every PR.
+
+### Prerequisites
+
+- Add a `CLOUDFLARE_API_TOKEN` secret to the repository, with permission to deploy the Worker.
+- The Worker must already exist in Cloudflare, and its preview domain must be configured (so `<alias>.<preview-domain>` resolves).
+- A `wrangler.jsonc` in the repo whose `name` matches the deployed Worker.
+
+### [`cloudflare-deploy.yml`](./.github/workflows/cloudflare-deploy.yml)
+
+Call this from a workflow named `Deploy` (the name is referenced by the preview workflow) that triggers on `push` to your production branch(es) and on `pull_request`:
+
+```yml
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  deploy:
+    if: github.repository_owner == 'withastro'
+    permissions:
+      contents: read
+    uses: withastro/automation/.github/workflows/cloudflare-deploy.yml@<commit-sha> # vX.Y.Z
+    with:
+      preview-domain: previews.my-worker.astro.build
+      artifact-paths: |
+        dist/
+        worker.js
+        wrangler.jsonc
+      # Optional build setup (omit all of these for a repo with no build step):
+      node-version: "24.18.0"
+      package-manager: pnpm
+      install-command: pnpm install
+      build-command: pnpm build
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+```
+
+#### Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `preview-domain` | yes | — | Base domain for preview URLs, e.g. `previews.docs.astro.build`. The branch alias is prepended. |
+| `artifact-paths` | yes | — | Newline-delimited files/dirs to hand off to the preview workflow. Must include your wrangler config and everything `wrangler deploy` needs. |
+| `deploy-command` | no | `deploy` | The `wrangler-action` command used for the production deploy. |
+| `build-command` | no | `""` | Shell command that produces the build output. Skipped when empty. |
+| `install-command` | no | `""` | Shell command to install dependencies (e.g. `pnpm install`). Skipped when empty. |
+| `node-version` | no | `""` | If set, installs Node.js (and pnpm when `package-manager` is `pnpm`). |
+| `package-manager` | no | `pnpm` | Package manager used for dependency caching: `pnpm` or `npm`. |
+| `node-options` | no | `""` | Value for `NODE_OPTIONS` during the build (e.g. `--max_old_space_size=8192`). |
+| `wrangler-version` | no | `""` | Pin the wrangler version used by `wrangler-action`. |
+
+### [`cloudflare-deploy-preview.yml`](./.github/workflows/cloudflare-deploy-preview.yml)
+
+Call this from a second workflow triggered by `workflow_run` on completion of your `Deploy` workflow:
+
+```yml
+name: Deploy Preview
+
+on:
+  workflow_run:
+    workflows: ["Deploy"]
+    types: [completed]
+
+jobs:
+  deploy-preview:
+    if: github.repository_owner == 'withastro'
+    permissions:
+      pull-requests: write
+    uses: withastro/automation/.github/workflows/cloudflare-deploy-preview.yml@<commit-sha> # vX.Y.Z
+    with:
+      worker-name: my-worker
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+```
+
+#### Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `worker-name` | yes | — | Worker to publish the preview against. Previews are always created on this Worker so they resolve on its preview domain. |
+| `wrangler-version` | no | `""` | Pin the wrangler version used by `wrangler-action`. |
+
 ## Releases
 
 To publish a new release of the reusable workflows:

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ on:
     branches: [main]
   pull_request:
 
+permissions: {}
+
 jobs:
   deploy:
     if: github.repository_owner == 'withastro'

--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 ```
 
+### How fork previews stay safe
+
+GitHub doesn't give fork pull requests access to secrets, so the two workflows split the work:
+
+- `Deploy` runs on the PR **without the token**. It only builds and uploads the result as an artifact — it never deploys.
+- `Deploy Preview` then runs on `workflow_run`, using the workflow file from your default branch **with the token**. It only downloads that artifact and publishes the preview — it never runs the fork's code.
+
+So the untrusted side never sees the token, and the trusted side never runs untrusted code.
+
 ## Releases
 
 To publish a new release of the reusable workflows:

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ on:
     workflows: ['Deploy']
     types: [completed]
 
+permissions: {}
+
 jobs:
   deploy-preview:
     if: github.repository_owner == 'withastro'

--- a/README.md
+++ b/README.md
@@ -95,21 +95,11 @@ jobs:
     secrets: inherit
 ```
 
-## Cloudflare Worker deploys
+## [`cloudflare-deploy.yml`](./.github/workflows/cloudflare-deploy.yml)
 
-Two reusable workflows deploy a Cloudflare Worker to production on pushes and publish per-PR previews. They are split into two files on purpose, for security: the deploy workflow runs on the `pull_request` event (untrusted fork code, no token on forks) and never deploys PR code — it only deploys to production on `push` and hands PRs off as artifacts. The preview workflow runs on `workflow_run` in the trusted base-repo context, consuming only those artifacts (it never checks out or runs PR code) and interpolating only sanitized values (a numeric PR number and an `[a-z0-9-]` alias).
+This workflow deploys a Cloudflare Worker to production on pushes, and on pull requests uploads the build output and PR metadata for [`cloudflare-deploy-preview.yml`](#cloudflare-deploy-previewyml) to publish a preview. It requires a `CLOUDFLARE_API_TOKEN` secret and a `wrangler.jsonc` whose `name` matches the Worker.
 
-Using both gives you production deploys on your default branch plus a `https://<branch-alias>.<preview-domain>` preview commented on every PR.
-
-### Prerequisites
-
-- Add a `CLOUDFLARE_API_TOKEN` secret to the repository, with permission to deploy the Worker.
-- The Worker must already exist in Cloudflare, and its preview domain must be configured (so `<alias>.<preview-domain>` resolves).
-- A `wrangler.jsonc` in the repo whose `name` matches the deployed Worker.
-
-### [`cloudflare-deploy.yml`](./.github/workflows/cloudflare-deploy.yml)
-
-Call this from a workflow named `Deploy` (the name is referenced by the preview workflow) that triggers on `push` to your production branch(es) and on `pull_request`:
+### Usage
 
 ```yml
 name: Deploy
@@ -131,39 +121,28 @@ jobs:
         dist/
         worker.js
         wrangler.jsonc
-      # Optional build setup (omit all of these for a repo with no build step):
-      node-version: "24.18.0"
-      package-manager: pnpm
-      install-command: pnpm install
-      build-command: pnpm build
+      # Optional build setup, omit for a repo with no build step:
+      node-version: '24.18.0'
+      install-command: 'pnpm install'
+      build-command: 'pnpm build'
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 ```
 
-#### Inputs
+See the [workflow inputs](./.github/workflows/cloudflare-deploy.yml) for the full list of options.
 
-| Input | Required | Default | Description |
-| --- | --- | --- | --- |
-| `preview-domain` | yes | — | Base domain for preview URLs, e.g. `previews.docs.astro.build`. The branch alias is prepended. |
-| `artifact-paths` | yes | — | Newline-delimited files/dirs to hand off to the preview workflow. Must include your wrangler config and everything `wrangler deploy` needs. |
-| `deploy-command` | no | `deploy` | The `wrangler-action` command used for the production deploy. |
-| `build-command` | no | `""` | Shell command that produces the build output. Skipped when empty. |
-| `install-command` | no | `""` | Shell command to install dependencies (e.g. `pnpm install`). Skipped when empty. |
-| `node-version` | no | `""` | If set, installs Node.js (and pnpm when `package-manager` is `pnpm`). |
-| `package-manager` | no | `pnpm` | Package manager used for dependency caching: `pnpm` or `npm`. |
-| `node-options` | no | `""` | Value for `NODE_OPTIONS` during the build (e.g. `--max_old_space_size=8192`). |
-| `wrangler-version` | no | `""` | Pin the wrangler version used by `wrangler-action`. |
+## [`cloudflare-deploy-preview.yml`](./.github/workflows/cloudflare-deploy-preview.yml)
 
-### [`cloudflare-deploy-preview.yml`](./.github/workflows/cloudflare-deploy-preview.yml)
+This workflow publishes a Cloudflare Worker preview for a pull request and comments the preview URL. It runs from the trusted base-repo context (via `workflow_run`) so it can deploy fork PRs safely without exposing the token. Use it alongside [`cloudflare-deploy.yml`](#cloudflare-deployyml).
 
-Call this from a second workflow triggered by `workflow_run` on completion of your `Deploy` workflow:
+### Usage
 
 ```yml
 name: Deploy Preview
 
 on:
   workflow_run:
-    workflows: ["Deploy"]
+    workflows: ['Deploy']
     types: [completed]
 
 jobs:
@@ -177,13 +156,6 @@ jobs:
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 ```
-
-#### Inputs
-
-| Input | Required | Default | Description |
-| --- | --- | --- | --- |
-| `worker-name` | yes | — | Worker to publish the preview against. Previews are always created on this Worker so they resolve on its preview domain. |
-| `wrangler-version` | no | `""` | Pin the wrangler version used by `wrangler-action`. |
 
 ## Releases
 


### PR DESCRIPTION
This adds two workflows for better reusability in projects:

- `cloudflare-deploy-preview.yml` - For pull requests, this creates a preview release, supports forks. It runs in the scope of the repo, gets the built artifacts and does the actual deployment.
- `cloudflare-deploy.yml` - Builds and deploys. For the main branch, does the deploy. For non-main it builds and stores the result in artifacts so that `cloudflare-deploy-preview.yml` can deploy them.