### PR TITLE
Install wrangler with npm in Cloudflare deploy workflows

### DIFF
--- a/.github/workflows/cloudflare-deploy-preview.yml
+++ b/.github/workflows/cloudflare-deploy-preview.yml
@@ -114,6 +114,10 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           wranglerVersion: ${{ inputs.wrangler-version }}
+          # Install wrangler with npm (always present on the runner). Otherwise
+          # wrangler-action infers the package manager from a lockfile in the
+          # downloaded artifact and fails when e.g. pnpm isn't set up.
+          packageManager: npm
           # Always create the preview on the named Worker so previews use its
           # preview domain, even for PRs targeting version branches.
           command: preview --worker-name ${{ inputs.worker-name }} --name "${{ steps.metadata.outputs.preview_alias }}"

--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -117,6 +117,10 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           wranglerVersion: ${{ inputs.wrangler-version }}
+          # Install wrangler with npm (always present on the runner). Otherwise
+          # wrangler-action infers the package manager from the repo's lockfile
+          # and fails when e.g. pnpm isn't set up (repos with no build step).
+          packageManager: npm
           command: ${{ inputs.deploy-command }}
 
       - name: Upload build output


### PR DESCRIPTION
## Changes

- Set `packageManager: npm` on the `wrangler-action` steps in both `cloudflare-deploy.yml` and `cloudflare-deploy-preview.yml`.
- Without this, `wrangler-action` infers the package manager from the project's lockfile and falls over when that manager isn't installed. This breaks any consumer with **no build step** (nothing sets up pnpm), e.g. `withastro/fonts-cdn`, which failed on `main` with `Unable to locate executable file: pnpm`.
- How wrangler-action installs its own CLI is independent of how the project builds, so forcing npm (always present on the runner) is safe for every consumer, including pnpm-based ones.

## Testing

- No automated tests (this repo has none for workflows). Validated both files parse as YAML. Real validation is the fonts-cdn deploy once this is released and the consumer bumps to the new tag.

## Docs

- No docs update needed; the change is internal to the workflows and doesn't alter any documented inputs.
