### PR TITLE
feat: define secrets in reusable format workflow to allow specific secrets passing

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,6 +8,9 @@ on:
         default: "format"
         required: false
         type: string
+    secrets:
+      FREDKBOT_GITHUB_TOKEN:
+        required: true
 
 jobs:
   format:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ jobs:
     with:
       # Set command to this repository’s package script that runs Prettier
       command: 'format:ci'
-    secrets: inherit
+    secrets:
+      FREDKBOT_GITHUB_TOKEN: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
 ```
 
 ## [`cloudflare-deploy.yml`](./.github/workflows/cloudflare-deploy.yml)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ When writing congrats messages, remember that `<names>` could be one, two, or mo
 
 ## [`format.yml`](./.github/workflows/format.yml)
 
-This workflow runs a repository’s code formatting tooling (e.g. Prettier) and commits any resulting changes directly.
+This workflow runs a repository’s code formatting tooling (e.g. Prettier). It needs the `FREDKBOT_GITHUB_TOKEN` to be passed as a secrets parameter to be able to commits any resulting changes directly.
 
 ### Usage
 


### PR DESCRIPTION
#### Description

This PR prepares the reusable format workflow to allow specific passing of the `FREDKBOT_GITHUB_TOKEN` secret. It also updates the example in the `README.md` to the recommended approach, which will be enabled through the changes in `format.yml`.

I also confirmed that all the other reusable workflows here do support this feature already, so we could potentially integrate Zizmor in other repos in the future as well 👀 

#### Related PRs

- https://github.com/withastro/starlight/pull/4011